### PR TITLE
 SSL auto renewal for wp frontend containers

### DIFF
--- a/wp/docker-compose.yml
+++ b/wp/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - ./wp-content/themes/lahma_maker:/var/www/html/wp-content/themes/lahma_maker 
       - ./nginx-conf:/etc/nginx/conf.d
       - certbot-etc:/etc/letsencrypt
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     networks:
       - app-network
 
@@ -60,7 +61,7 @@ services:
     volumes:
       - certbot-etc:/etc/letsencrypt
       - wordpress:/var/www/html
-    command: certonly --webroot --webroot-path=/var/www/html --email sammy@example.com --agree-tos --no-eff-email -d example.com -d www.example.com
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
 
 volumes:
   certbot-etc:


### PR DESCRIPTION
Before we were only able to manually renew SSL certs for our frontend. 

With the new docker-compose frontend setup it's easy to add automation for this as well without using cronjobs. We can just give the containers default commands that involves infinite loop and sleep.

The certbot server will check if renewal is needed every 12 hours (recommended by the LE team) and nginx server reloads itself every 6 hours so that new certs are picked up soonest. 

Fixes #136 