### PR TITLE
RIP Exit and move to alumni, new show zeneszen, adjust Donald Kacsa slot

### DIFF
--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -444,7 +444,7 @@ radio = switch(track_sensitive=false, transitions=[
     ({6w and 10h30m-21h30m}, off_air_ambient_mix),                     #ambient: Merites - Brains
     ({7w and 9h30m-11h29m}, once(playlist_lohuma)),                    #Sunday
     ({7w and 11h30m-12h59m}, once(playlist_bambusz)),
-    ({7w and 13h-16h59m}, once(playlist_donald_kacsa_klub)),
+    ({7w and 13h-15h59m}, once(playlist_donald_kacsa_klub)),
     ({7w and 17h-17h59m}, once(playlist_hetedik_tipusu_talalkozas)),
     ({7w and 19h-19h59m}, once(playlist_ltmshow)),
     ({7w and 20h-20h59m}, once(playlist_sub_burek)),

--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -146,9 +146,6 @@ playlist_jambikus_nesz = audio_to_stereo(id="stereo_playlist_jambikus_nesz", pla
 playlist_mosolyszunet = playlist(id="playlist_mosolyszunet",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_mosolyszunet.m3u")
 playlist_mosolyszunet = audio_to_stereo(id="stereo_playlist_mosolyszunet", playlist_mosolyszunet)
 
-playlist_exit = playlist(id="playlist_exit",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_exit.m3u")
-playlist_exit = audio_to_stereo(id="stereo_playlist_exit", playlist_exit)
-
 playlist_lohuma = playlist(id="playlist_lohuma",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_lohuma.m3u")
 playlist_lohuma = audio_to_stereo(id="stereo_playlist_lohuma", playlist_lohuma)
 
@@ -187,6 +184,9 @@ playlist_hirszalonna = audio_to_stereo(id="stereo_playlist_hirszalonna", playlis
 
 playlist_moneyka = playlist(id="playlist_moneyka",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_moneyka.m3u")
 playlist_moneyka = audio_to_stereo(id="stereo_playlist_moneyka", playlist_moneyka)
+
+playlist_zeneszen playlist(id="playlist_zeneszen",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_zeneszen.m3u")
+playlist_zeneszen = audio_to_stereo(id="stereo_playlist_zeneszen", playlist_zeneszen)
 
 # Jingle playlists
 playlist_jingle_station_id = playlist(id="playlist_jingle_station_id",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_jingle_station_id.m3u")
@@ -448,8 +448,8 @@ radio = switch(track_sensitive=false, transitions=[
     ({7w and 17h-17h59m}, once(playlist_hetedik_tipusu_talalkozas)),
     ({7w and 19h-19h59m}, once(playlist_ltmshow)),
     ({7w and 20h-20h59m}, once(playlist_sub_burek)),
-    ({7w and 21h-21h59m}, once(playlist_exit)),
-    ({7w and 9h30m-21h30m}, off_air_ambient_mix),                        #ambient: Lohuma - Exit
+    ({7w and 21h-21h59m}, once(playlist_zeneszen)),
+    ({7w and 9h30m-21h30m}, off_air_ambient_mix),                        #ambient: Lohuma - Zeneszen
     ({true}, radio) ])
 
 

--- a/wp/wp-content/themes/lahma_maker/Showsschedule.php
+++ b/wp/wp-content/themes/lahma_maker/Showsschedule.php
@@ -83,7 +83,7 @@
     <ul>
         <li>10:30–12:30 <strong><a href="../shows/sunday-lockdown-w-lohuma/">Sunday Lockdown w/ Lohuma</a></strong></li>
         <li>12:30–14:00 <strong><a href="../shows/bambuszradio-with-panda/">Bambuszradio with Panda</a></strong></li>
-        <li>14:00–18:00 <strong><a href="../shows/donald-kacsa-klub/">Donald Kacsa Klub</a></strong></li>
+        <li>14:00–17:00 <strong><a href="../shows/donald-kacsa-klub/">Donald Kacsa Klub</a></strong></li>
         <li>18:00–19:00 <strong><a href="../shows/hetedik-tipusu-talalkozas/">Hetedik Típusú Találkozás</a></strong> </li>
         <li>20:00–21:00 <strong><a href="../shows/the-ltm-show/">The LTM Show</a></strong></li>
         <li>21:00–22:00 <strong><a href="../shows/sub-burek/">Sub Burek</a></strong></li>

--- a/wp/wp-content/themes/lahma_maker/Showsschedule.php
+++ b/wp/wp-content/themes/lahma_maker/Showsschedule.php
@@ -87,6 +87,6 @@
         <li>18:00–19:00 <strong><a href="../shows/hetedik-tipusu-talalkozas/">Hetedik Típusú Találkozás</a></strong> </li>
         <li>20:00–21:00 <strong><a href="../shows/the-ltm-show/">The LTM Show</a></strong></li>
         <li>21:00–22:00 <strong><a href="../shows/sub-burek/">Sub Burek</a></strong></li>
-        <li>22:00-23:00 <strong><a href="../shows/exit/">Exit</a></strong></li>
+        <li>22:00-23:00 <strong><a href="../shows/zeneszen-avagy-a-rizskeksz-latvanya/">Zenészen (avagy a rizskeksz látványa)</a></strong></li>
     </ul>
 </div>


### PR DESCRIPTION
- Rip Exit 
- New show Zeneszen
Took over slot for Exit on Showsschedule and liquidsoap 
No change in transitions
Added zeneszen playlist in Az, zeneszen show on archives, show page on frontend, uploaded first ep

- Shorter show
Staple Dkk tightens their show so now it is 1 hour less. Adusted that too.

It's reassuring and calming to see that I made the very same changes locally during the week that you did while neither of us knew what the other is doing