### PR TITLE
New show/gestalt

### DIFF
--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -191,6 +191,9 @@ playlist_zeneszen = audio_to_stereo(id="stereo_playlist_zeneszen", playlist_zene
 playlist_queer = playlist(id="playlist_queer",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_queer.m3u")
 playlist_queer = audio_to_stereo(id="stereo_playlist_queer", playlist_queer)
 
+playlist_linear_systems_with_gestalt = playlist(id="playlist_linear_systems_with_gestalt",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_linear_systems_with_gestalt.m3u")
+playlist_linear_systems_with_gestalt = audio_to_stereo(id="stereo_playlist_linear_systems_with_gestalt", playlist_linear_systems_with_gestalt)
+
 # Jingle playlists
 playlist_jingle_station_id = playlist(id="playlist_jingle_station_id",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_jingle_station_id.m3u")
 playlist_jingle_station_id = audio_to_stereo(id="stereo_playlist_jingle_station_id", playlist_jingle_station_id)
@@ -376,6 +379,7 @@ radio = switch(track_sensitive=false, transitions=[
     transition_into_show(playlist_jingle_station_id),
     transition_into_show(playlist_jingle_station_id),
     transition_into_show(playlist_jingle_station_id),
+    transition_into_show(playlist_jingle_station_id),
     transition_into_off(playlist_jingle_station_id), #ambient: Saturday
     transition_into_show(playlist_jingle_station_id),
     transition_into_show(playlist_jingle_station_id),
@@ -445,7 +449,8 @@ radio = switch(track_sensitive=false, transitions=[
     ({6w and 17h-18h59m}, once(playlist_rnr666)),
     ({6w and 19h-20h59m}, once(playlist_mood_sequence)),
     ({6w and 21h00m-21h59m}, once(playlist_brains_sublimating)),
-    ({6w and 10h30m-21h30m}, off_air_ambient_mix),                     #ambient: Merites - Brains
+    ({6w23h30m-7w0h29m}, once(playlist_linear_systems_with_gestalt)),
+    ({6w10h30m-7w0h30m}, off_air_ambient_mix),                     #ambient: Merites - Gestalt
     ({7w and 9h30m-11h29m}, once(playlist_lohuma)),                    #Sunday
     ({7w and 11h30m-12h59m}, once(playlist_bambusz)),
     ({7w and 13h-15h59m}, once(playlist_donald_kacsa_klub)),

--- a/wp/wp-content/themes/lahma_maker/Showsschedule.php
+++ b/wp/wp-content/themes/lahma_maker/Showsschedule.php
@@ -76,6 +76,7 @@
         <li>18:00–20:00 <strong><a href="../shows/rnr666-radioshow/">RNR666 radioshow</a></strong></li>
         <li>20:00–22:00 <strong><a href="../shows/mood-sequence/">Mood Sequence</a></strong></li>
         <li>22:00–23:00 <strong><a href="../shows/brains-sublimating/">Brains Sublimating</a></strong></li>
+        <li>00:30–01:30 <strong><a href="../shows/linear-systems-with-gestalt/">Linear Systems with Gestalt!</a></strong></li>
     </ul>
 </div>
 <div class="Sunday day">


### PR DESCRIPTION
- added show on frontend schedule can be viewed on test server -- added it to Saturday's schedule still
- added show to our liquidsoap config had to try new date range schema as we seem to need to accomodate overnight broadcast. I haven't tested this solution directly but the config has been parsed successfully on test broadcast servers. This is from test servers logs. 
```
2021/02/05 00:28:40 [playlist_linear_systems_with_gestalt:3] Playlist treated as format application/x-mpegURL
2021/02/05 00:28:40 [playlist_linear_systems_with_gestalt:3] Successfully loaded a playlist of 1 tracks.
2021/02/05 00:28:40 [playlist_linear_systems_with_gestalt:4] Content kind is {audio=1+;video=0;midi=0}.
2021/02/05 00:28:40 [playlist_linear_systems_with_gestalt:4] Activations changed: static=[stereo_playlist_linear_systems_with_gestalt:sequence_8220:switch_8237:on_metadata_8243:lahmacun_radio_local_1:lahmacun_radio_local_1], dynamic=[].
2021/02/05 00:28:40 [stereo_playlist_linear_systems_with_gestalt:4] Activations changed: static=[sequence_8220:switch_8237:on_metadata_8243:lahmacun_radio_local_1:lahmacun_radio_local_1], dynamic=[].

```

- added to arcsi