### PR TITLE
1st season of queer talks is over

### DIFF
--- a/azuracast/liquidsoap_custom.liq
+++ b/azuracast/liquidsoap_custom.liq
@@ -184,9 +184,6 @@ playlist_moneyka = audio_to_stereo(id="stereo_playlist_moneyka", playlist_moneyk
 playlist_zeneszen = playlist(id="playlist_zeneszen",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_zeneszen.m3u")
 playlist_zeneszen = audio_to_stereo(id="stereo_playlist_zeneszen", playlist_zeneszen)
 
-playlist_queer = playlist(id="playlist_queer",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_queer.m3u")
-playlist_queer = audio_to_stereo(id="stereo_playlist_queer", playlist_queer)
-
 playlist_linear_systems_with_gestalt = playlist(id="playlist_linear_systems_with_gestalt",mode="randomize",reload_mode="watch",conservative=true,default_duration=10.,length=20.,"/var/azuracast/stations/lahmacun_radio/playlists/playlist_linear_systems_with_gestalt.m3u")
 playlist_linear_systems_with_gestalt = audio_to_stereo(id="stereo_playlist_linear_systems_with_gestalt", playlist_linear_systems_with_gestalt)
 
@@ -399,7 +396,6 @@ radio = switch(track_sensitive=false, transitions=[
     transition_into_show(playlist_jingle_station_id),
     transition_into_show(playlist_jingle_station_id),
     transition_into_show(playlist_jingle_station_id),
-    transition_into_show(playlist_jingle_station_id),
     transition_into_off(playlist_jingle_station_id), #ambient: Sunday
     transition_into_off(playlist_jingle_station_id) ], 
     transition_length=60., #max duration of jingle (60s)
@@ -467,7 +463,6 @@ radio = switch(track_sensitive=false, transitions=[
     ({7w and 8h30m-10h29m}, once(playlist_lohuma)),                    #Sunday
     ({7w and 10h30m-11h59m}, once(playlist_bambusz)),
     ({7w and 12h-14h59m}, once(playlist_donald_kacsa_klub)),
-    ({7w and 15h-15h59m}, once(playlist_queer)),
     ({7w and 16h-16h59m}, once(playlist_hetedik_tipusu_talalkozas)),
     ({7w and 17h-17h59m}, once(playlist_hatterzaj)),
     ({7w and 18h-18h59m}, once(playlist_ltmshow)),

--- a/wp/wp-content/themes/lahma_maker/Showsschedule.php
+++ b/wp/wp-content/themes/lahma_maker/Showsschedule.php
@@ -87,7 +87,6 @@
         <li>10:30–12:30 <strong><a href="../shows/sunday-lockdown-w-lohuma/">Sunday Lockdown w/ Lohuma</a></strong></li>
         <li>12:30–14:00 <strong><a href="../shows/bambuszradio-with-panda/">Bambuszradio with Panda</a></strong></li>
         <li>14:00–17:00 <strong><a href="../shows/donald-kacsa-klub/">Donald Kacsa Klub</a></strong></li>
-        <li>17:00–18:00 <strong><a href="../shows/queer-budapest-talks/">Queer Budapest Talks</a></strong></li>
         <li>18:00–19:00 <strong><a href="../shows/hetedik-tipusu-talalkozas/">Hetedik Típusú Találkozás</a></strong> </li>
         <li>19:00–20:00 <strong><a href="../shows/hatterzaj/">Háttérzaj</a></strong> </li>
         <li>20:00–21:00 <strong><a href="../shows/the-ltm-show/">The LTM Show</a></strong></li>


### PR DESCRIPTION
For now we should remove them from the schedule and from our broadcast rotation

Other tasks
- move to past shows cat on front-end
- remove playlist and assets on broadcast server

This PR depends on #406 so it will be merged only after that one. 

Please review the removed code. Thanks!