### PR TITLE
Attempt to fix archive unavailability bringing the radio down

### DIFF
--- a/wp/wp-content/themes/lahma_maker/template-parts/content-arcsi.php
+++ b/wp/wp-content/themes/lahma_maker/template-parts/content-arcsi.php
@@ -15,7 +15,7 @@ function isDomainAvailable($domain) {
         //initialize curl
         $curlInit = curl_init($domain);
         curl_setopt($curlInit,CURLOPT_CONNECTTIMEOUT,10);
-        curl_setopt($curlInit,CURLOPT_TIMEOUT,40);
+        curl_setopt($curlInit,CURLOPT_TIMEOUT,11);
         curl_setopt($curlInit,CURLOPT_HEADER,true);
         curl_setopt($curlInit,CURLOPT_NOBODY,true);
         curl_setopt($curlInit,CURLOPT_RETURNTRANSFER,true);

--- a/wp/wp-content/themes/lahma_maker/template-parts/content-arcsi.php
+++ b/wp/wp-content/themes/lahma_maker/template-parts/content-arcsi.php
@@ -15,12 +15,19 @@ function isDomainAvailable($domain) {
         //initialize curl
         $curlInit = curl_init($domain);
         curl_setopt($curlInit,CURLOPT_CONNECTTIMEOUT,10);
+        curl_setopt($curlInit,CURLOPT_TIMEOUT,40);
         curl_setopt($curlInit,CURLOPT_HEADER,true);
         curl_setopt($curlInit,CURLOPT_NOBODY,true);
         curl_setopt($curlInit,CURLOPT_RETURNTRANSFER,true);
 
         //get response code from answer
-        $response = curl_exec($curlInit);
+        curl_exec($curlInit);
+        //arcsi is unreachable so curl timeout is reached
+        if (curl_errno($curlInit)) {
+            if (in_array(curl_errno($curlInit), array(CURLE_OPERATION_TIMEDOUT, CURLE_OPERATION_TIMEOUTED))) {
+                return false;
+            }
+        }
         $responseCode = curl_getinfo($curlInit, CURLINFO_HTTP_CODE);
         
         curl_close($curlInit);

--- a/wp/wp-content/themes/lahma_maker/template-parts/content-arcsi.php
+++ b/wp/wp-content/themes/lahma_maker/template-parts/content-arcsi.php
@@ -6,11 +6,9 @@
  */
 
 //returns true, if domain is availible, false if not
-function isDomainAvailable($domain)
-{
+function isDomainAvailable($domain) {
         //check, if a valid url is provided
-        if(!filter_var($domain, FILTER_VALIDATE_URL))
-        {
+        if(!filter_var($domain, FILTER_VALIDATE_URL)) {
             return false;
         }
 
@@ -21,14 +19,17 @@ function isDomainAvailable($domain)
         curl_setopt($curlInit,CURLOPT_NOBODY,true);
         curl_setopt($curlInit,CURLOPT_RETURNTRANSFER,true);
 
-        //get answer
+        //get response code from answer
         $response = curl_exec($curlInit);
-
+        $responseCode = curl_getinfo($curlInit, CURLINFO_HTTP_CODE);
+        
         curl_close($curlInit);
 
-        if ($response) return true;
-
-        return false;
+        if ($responseCode>=200 && $responseCode<300) {
+                return true;
+        } else {
+                return false;
+        }
 }
 
 /**
@@ -66,21 +67,6 @@ $server = 'https://arcsi.lahmacun.hu'; // prod server
 // $server_internal = 'http://docker.for.mac.localhost:40'; // local server
 
 $showslug = get_post_field( 'post_name', get_post() );
-//$showjson = file_get_contents($server_internal . '/arcsi/show/' . $showslug . '/archive');
-$showjson = file_get_contents($server . '/arcsi/show/' . $showslug . '/archive');
-$showarcsi = json_decode($showjson, true);
-
-// print_r($showjson)
-
-/* CHECK IF THERE ARE ARCHIVED SHOWS */
-$has_archived = false;
-
-foreach ($showarcsi as $v_arr) {
-    if ($v_arr['archived']) {
-        $has_archived = true;
-    }
-}
-
 ?>
 
 <?php 
@@ -90,86 +76,92 @@ if (!isDomainAvailable($server)) {
     echo 'الدمام 🤯 Arcsi is ❌ not available 🚧 at the moment 😬 نحن اسفون <br/>
     🧤 🔥 🎯 Please try again later 👉 💫 🔊';
     echo '</center></h3>';
-}
+} else {
+    // if arcsi is available for the Show
+    // check all shows if all 
+    $showjson = file_get_contents($server . '/arcsi/show/' . $showslug . '/archive');
+    $showarcsi = json_decode($showjson, true);
 
-// if arcsi is available for the Show
-// check all shows if all 
-if (isDomainAvailable($server) && $showjson && $has_archived): ?>
+    /* CHECK IF THERE ARE ARCHIVED SHOWS */
+    $has_archived = false;
 
-<article class="arcsi-list" >
+    foreach ($showarcsi as $v_arr) {
+        if ($v_arr['archived']) {
+            $has_archived = true;
+        }
+    }
+    if ($showjson && $has_archived): 
+?>  
+    <article class="arcsi-list" >
 
-<h3>Arcsived shows for <?php the_title(); ?></h3>
+        <h3>Arcsived shows for <?php the_title(); ?></h3>
 
-<div class="sort-block">
-    <button id="alphabetical" style="margin-right: 1rem;">
-        <i class="fa fa-sort-alpha-asc" aria-hidden="true"></i> Order by Title
-    </button>
-    <button id="bydate">
-        <i class="fa fa-sort-numeric-desc" aria-hidden="true"></i> Order by Air time
-    </button>
-</div>
-
-<div class="arcsi-blokks">
-
-<?php 
-
-$showarcsi = sortAssociativeArrayByKey($showarcsi, "play_date", "DESC");
-
-foreach($showarcsi as $archiveitem) :
-    $showtitle = get_the_title();
-    $showarchived = $archiveitem['archived'];
-    $shownumber = $archiveitem['number'];
-    $showname = $archiveitem['name'];
-    $showimg = $archiveitem['image_url'];
-    $showdescription = $archiveitem['description'];
-    $showplaydate = $archiveitem['play_date'];
-    $showid = $archiveitem['id'];
-?>
-
-<?php 
-// if Episode is archived
-if ($showarchived) { 
-    
-$fullTitle = $showtitle . ' | ' . $showname;
-    
-?>
-
-
-<div class="arcsiblokk">
-    <div class="arcsiimage">
-        <a href="<?php echo $showimg;?>" class="swipebox">
-            <img src="<?php echo $showimg;?>" alt="<?php echo $showname; ?>">
-        </a>
-    </div>
-    <div class="arcsiinfos">
-        <div>
-        <?php /* no episode number ?> 
-        Episode nr. <?php echo $shownumber; ?> – 
-        <?php */ ?> 
-        Aired on <span class="airtime"><?php echo $showplaydate; ?></span> </div>
-        <h4 class="episode-name"><?php echo $showname; ?></h4>   
-        <p><?php echo $showdescription; ?></p> 
-        <div id="arcsi-audio-<?php echo $showid; ?>" class="arcsicontrols">
-            <a class="arcsibutton arcsidown avoidAjax" href="#" data-href="<?php echo $server; ?>/arcsi/item/<?php echo $showid; ?>/download" title="<?php echo $fullTitle; ?>" 
-            data-showtitle="<?php echo $showtitle; ?>" data-episodetitle="<?php echo $showname; ?>">
-                <i class="fa fa-download" aria-hidden="true"></i> Download
-            </a>              
-            <a class="arcsibutton arcsilisten avoidAjax" href="<?php echo $server; ?>/arcsi/item/<?php echo $showid; ?>/listen" title="<?php echo $fullTitle; ?>"
-            data-showtitle="<?php echo $showtitle; ?>" data-episodetitle="<?php echo $showname; ?>">
-                <i class="fa fa-headphones" aria-hidden="true"></i> Listen
-            </a>
+        <div class="sort-block">
+                <button id="alphabetical" style="margin-right: 1rem;">
+                        <i class="fa fa-sort-alpha-asc" aria-hidden="true"></i> Order by Title
+                </button>
+                <button id="bydate">
+                        <i class="fa fa-sort-numeric-desc" aria-hidden="true"></i> Order by Air time
+                </button>
         </div>
-    </div>
-</div>
-  
-<?php
-} // endif
-endforeach;
+
+        <div class="arcsi-blokks">
+                
+<?php 
+
+        $showarcsi = sortAssociativeArrayByKey($showarcsi, "play_date", "DESC");
+
+        foreach($showarcsi as $archiveitem) :
+            $showtitle = get_the_title();
+            $showarchived = $archiveitem['archived'];
+            $shownumber = $archiveitem['number'];
+            $showname = $archiveitem['name'];
+            $showimg = $archiveitem['image_url'];
+            $showdescription = $archiveitem['description'];
+            $showplaydate = $archiveitem['play_date'];
+            $showid = $archiveitem['id'];
+        
+                // if Episode is archived
+                if ($showarchived) { 
+                        $fullTitle = $showtitle . ' | ' . $showname;
 ?>
-</div>
-
-</article><!-- #post-## -->
-
+                        <div class="arcsiblokk">
+                            <div class="arcsiimage">
+                                <a href="<?php echo $showimg;?>" class="swipebox">
+                                    <img src="<?php echo $showimg;?>" alt="<?php echo $showname; ?>">
+                                </a>
+                            </div>
+                            <div class="arcsiinfos">
+                                <div>
+                                <?php /* no episode number ?> 
+                                Episode nr. <?php echo $shownumber; ?> – 
+                                <?php */ ?> 
+                                Aired on <span class="airtime"><?php echo $showplaydate; ?></span> </div>
+                                <h4 class="episode-name"><?php echo $showname; ?></h4>   
+                                <p><?php echo $showdescription; ?></p> 
+                                <div id="arcsi-audio-<?php echo $showid; ?>" class="arcsicontrols">
+                                    <a class="arcsibutton arcsidown avoidAjax" href="#" data-href="<?php echo $server; ?>/arcsi/item/<?php echo $showid; ?>/download" title="<?php echo $fullTitle; ?>" 
+                                    data-showtitle="<?php echo $showtitle; ?>" data-episodetitle="<?php echo $showname; ?>">
+                                        <i class="fa fa-download" aria-hidden="true"></i> Download
+                                    </a>              
+                                    <a class="arcsibutton arcsilisten avoidAjax" href="<?php echo $server; ?>/arcsi/item/<?php echo $showid; ?>/listen" title="<?php echo $fullTitle; ?>"
+                                    data-showtitle="<?php echo $showtitle; ?>" data-episodetitle="<?php echo $showname; ?>">
+                                        <i class="fa fa-headphones" aria-hidden="true"></i> Listen
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
 <?php
-// close if arcsi is available for the Show
-endif; ?>
+                } // endif showarchived
+        endforeach;
+?>
+        </div>
+    </article><!-- #post-## -->
+<?php        
+    // close if arcsi is available for the Show
+    endif; // endif showjson && hasarchived
+} // endif domain available
+?>
+
+
+


### PR DESCRIPTION
There was this call to file_get_contents() to $server that happened before invoking the isDomainAvailable() function. 

I think this was the root cause that whenever the archive's were unavailable the radio also broke down.

The goal was simple: 
 - do the isDomainAvailable() first
     - I changed this function just little bit to check that the response is valid status code (server exists and there are no errors -- in case we might use this later for checking against 404 shows / episodes)
 - do the archive json parse and `archived` check only after


I didn't have time yet to setup and try out locally if this fix works as intended so you may test yourself or wait for that please. But let's not merge it before those tests have been attempted. 
